### PR TITLE
Try to fix tests in appveyor build.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -35,4 +35,5 @@ build_script:
   - cmake --build . --config "%CONFIGURATION%"
 
 test_script:
+  - C:\projects\logging\build_dir\tests\Release\test-ext-logging.exe
   - ctest -C "%CONFIGURATION%" --rerun-failed --output-on-failure -VV

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -35,4 +35,4 @@ build_script:
   - cmake --build . --config "%CONFIGURATION%"
 
 test_script:
-  - ctest -C "%CONFIGURATION%" --output-on-failure
+  - ctest -C "%CONFIGURATION%" --rerun-failed --output-on-failure -VV

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -29,7 +29,7 @@ before_build:
   - if defined BINDIR (set "PATH=%BINDIR%;%PATH:C:\Program Files\Git\usr\bin;=%")
   - md build_dir
   - cd build_dir
-  - cmake -Wno-dev -DEXTLOG_TESTS=ON -DEXTLOG_EXAMPLES=ON --config "%CONFIGURATION%" -G "%GENERATOR%" ..
+  - cmake -Wno-dev -DEXTLOG_TESTS=ON -DEXTLOG_EXAMPLES=ON -G "%GENERATOR%" ..
 
 build_script:
   - cmake --build . --config "%CONFIGURATION%"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,13 +10,26 @@ foreach(test_name IN LISTS test-files${suffix}) # <- DO NOT EXPAND LIST
     list(APPEND test_sources "${test_name}.cpp")
 endforeach()
 
-set(test_target "test-ext-logging${suffix}")
-add_executable("${test_target}" gtest.cpp ${test_sources})
-target_include_directories("${test_target}" SYSTEM PRIVATE ${gtest_SOURCE_DIR}/include)
-target_link_libraries("${test_target}" ext::basics ext::logging gtest_main gtest Threads::Threads)
-target_compile_options("${test_target}" PRIVATE ${ext_stone-warnings})
-target_compile_definitions("${test_target}" PUBLIC EXT_CHECKED=1 EXT_IN_TEST=1)
-# -- repeated calls should append which does not happen for me (cmake 3.16 on linux)
-#target_compile_definitions("${test_target}" PUBLIC EXT_IN_TEST=1
-add_test(NAME "${test_target}_run" COMMAND $<TARGET_FILE:${test_target}>)
-set_target_properties (${test_target} PROPERTIES FOLDER tests/${test_target})
+foreach(suffix IN ITEMS "")
+    #build one executable
+    set(test_sources)
+    foreach(test_name IN LISTS test-files${suffix}) # <- DO NOT EXPAND LIST
+        list(APPEND test_sources "${test_name}.cpp")
+    endforeach()
+
+    set(test_target "test-ext-logging${suffix}")
+    add_executable("${test_target}" gtest.cpp ${test_sources})
+    target_include_directories("${test_target}" SYSTEM PRIVATE ${gtest_SOURCE_DIR}/include)
+    target_link_libraries("${test_target}"
+        ext::basics${suffix}
+        ext::logging${suffix}
+        gtest_main gtest
+        Threads::Threads
+    )
+    target_compile_options("${test_target}" PRIVATE ${ext_stone-warnings})
+    target_compile_definitions("${test_target}" PUBLIC EXT_CHECKED=1 EXT_IN_TEST=1)
+    # -- repeated calls should append which does not happen for me (cmake 3.16 on linux)
+    #target_compile_definitions("${test_target}" PUBLIC EXT_IN_TEST=1
+	add_test(NAME "${test_target}_run" COMMAND $<TARGET_FILE:${test_target}>)
+    set_target_properties (${test_target} PROPERTIES FOLDER tests/${test_target})
+endforeach()


### PR DESCRIPTION
Locally the tests build and run successfully in VisualStudio.

When using PowerShell locally the test output is the same as with appveyor:
```
test 1
    Start 1: test-ext-logging_run
1: Test command: C:\projects\logging\build_dir\tests\Release\test-ext-logging.exe
1: Test timeout computed to be: 1500
1/1 Test #1: test-ext-logging_run .............Exit code 0xc0000135
***Exception:   0.17 sec
0% tests passed, 1 tests failed out of 1
```
